### PR TITLE
Dispatch Flutter release from release-mobile workflow

### DIFF
--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -1,13 +1,10 @@
 name: Release Flutter SDK
 
-# Triggered by the flutter/v* tag created by release-mobile.yml.
-# Running under this tag ensures the OIDC token carries refs/tags/flutter/v*,
+# Dispatched by release-mobile.yml after it creates the flutter/v* tag.
+# Running under that tag ref ensures the OIDC token carries refs/tags/flutter/v*,
 # which matches the trusted-publishing tag pattern configured on pub.dev.
 on:
-  push:
-    tags:
-      # Must align with the tag pattern configured on pub.dev (flutter/v{{version}})
-      - "flutter/v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -29,6 +26,17 @@ jobs:
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.QUILTTY_RELEASE_GITHUB_TOKEN }}
+
+      - name: Validate ref is a flutter/v* tag
+        run: |
+          case "$GITHUB_REF" in
+            refs/tags/flutter/v*) ;;
+            *)
+              echo "ERROR: This workflow must run against a flutter/v* tag ref (got: $GITHUB_REF)"
+              echo "Dispatch via release-mobile.yml, or select a flutter/v* tag from the 'Use workflow from' dropdown."
+              exit 1
+              ;;
+          esac
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -116,6 +117,17 @@ jobs:
           if [ ${#tags_to_push[@]} -gt 0 ]; then
             git push --atomic origin "${tags_to_push[@]}"
           fi
+
+      - name: Dispatch Flutter release
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # Run release-flutter.yml at the flutter/v* tag ref so the OIDC token
+          # carries refs/tags/flutter/v*, matching the pub.dev tag pattern.
+          gh workflow run release-flutter.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "flutter/$VERSION"
+          echo "Dispatched release-flutter.yml at flutter/$VERSION"
 
   # ── 3a. Build, test, and publish Android to Maven Central ────────────────────
   publish-android:

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -124,10 +124,11 @@ jobs:
         run: |
           # Run release-flutter.yml at the flutter/v* tag ref so the OIDC token
           # carries refs/tags/flutter/v*, matching the pub.dev tag pattern.
+          # The tag created above is flutter/v$VERSION (note the "v" prefix).
           gh workflow run release-flutter.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "flutter/$VERSION"
-          echo "Dispatched release-flutter.yml at flutter/$VERSION"
+            --ref "flutter/v$VERSION"
+          echo "Dispatched release-flutter.yml at flutter/v$VERSION"
 
   # ── 3a. Build, test, and publish Android to Maven Central ────────────────────
   publish-android:


### PR DESCRIPTION
## Summary

Switches the Flutter SDK release from a self-triggering tag push to an explicit workflow_dispatch issued by release-mobile.yml, so the pub.dev trusted-publisher OIDC token is minted at the correct flutter/v* tag ref.
