### PR TITLE
Handle client reset consistently

### DIFF
--- a/.changeset/lazy-canyons-bake.md
+++ b/.changeset/lazy-canyons-bake.md
@@ -1,0 +1,6 @@
+---
+"@quiltt/react": patch
+"@quiltt/vue": patch
+---
+
+Prevent an unhandled promise rejection in `QuilttAuthProvider` when the session changes. `resetStore()` cancels in-flight queries while clearing data cached under the previous session, and can reject while doing so — the provider now catches and ignores this expected rejection, matching the handling already in the `vue` plugin.

--- a/packages/react/src/providers/QuilttAuthProvider.tsx
+++ b/packages/react/src/providers/QuilttAuthProvider.tsx
@@ -94,10 +94,14 @@ export const QuilttAuthProvider: FC<QuilttAuthProviderProps> = ({
     }
   }, [token, session])
 
-  // Reset Client Store when session changes (using deep comparison)
+  // Reset the Apollo store when the session changes so data cached under a previous
+  // session is never served to a different one.
   useEffect(() => {
     if (!isDeepEqual(session, previousSessionRef.current)) {
-      apolloClient.resetStore()
+      apolloClient.resetStore().catch(() => {
+        // resetStore cancels and refetches active queries; the rejection it emits for the
+        // cancelled in-flight queries is expected, so ignore it.
+      })
       previousSessionRef.current = session
     }
   }, [session, apolloClient])

--- a/packages/react/src/utils/isDeepEqual.ts
+++ b/packages/react/src/utils/isDeepEqual.ts
@@ -7,6 +7,8 @@
  * ```ts
  * isDeepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } }) // true
  * isDeepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 3 } }) // false
+ * isDeepEqual(undefined, undefined) // true
+ * isDeepEqual(null, null) // true
  * ```
  */
 export const isDeepEqual = (obj1: unknown, obj2: unknown): boolean => {

--- a/packages/react/tests/providers/QuilttAuthProvider.test.tsx
+++ b/packages/react/tests/providers/QuilttAuthProvider.test.tsx
@@ -34,7 +34,8 @@ vi.mock('@apollo/client/react', () => ({
 
 vi.mock('@quiltt/core', () => {
   class MockQuilttClient {
-    resetStore = vi.fn()
+    // resetStore must return a promise since the provider chains .catch() on it
+    resetStore = vi.fn(() => Promise.resolve())
   }
   class MockInMemoryCache {}
   class MockTerminatingLink {}

--- a/packages/vue/src/plugin/QuilttPlugin.ts
+++ b/packages/vue/src/plugin/QuilttPlugin.ts
@@ -140,12 +140,13 @@ export const QuilttPlugin: Plugin<[QuilttPluginOptions?]> = {
     stopSessionWatcher = watch(
       () => session.value,
       (newSession, oldSession) => {
-        // Reset the GraphQL store whenever the session actually changes (mirrors
-        // React's QuilttAuthProvider). Skip the initial immediate run, where Vue
-        // passes `undefined` as the previous value.
+        // Reset the Apollo store whenever the session changes so data cached under a
+        // previous session is never served to a different one. Skip the initial immediate
+        // run, where Vue passes `undefined` as the previous value.
         if (oldSession !== undefined && newSession !== oldSession) {
           apolloClient.resetStore().catch(() => {
-            // resetStore rejects if in-flight queries are aborted; safe to ignore.
+            // resetStore cancels and refetches active queries; the rejection it emits for the
+            // cancelled in-flight queries is expected, so ignore it.
           })
         }
 


### PR DESCRIPTION
## Summary
Makes the rest of the cache upon session change consistent across Vue + React, preventing certain Connector errors

<!--- CHANGELOG_START -->
## Improvements <!--- Delete if not needed -->
- Align Apollo reset store behaviors across packages






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update keeps Apollo cache state isolated across authentication session changes in the React and Vue SDKs, while safely handling expected rejected resets from cancelled in-flight queries. The React provider test mock now returns a promise consistent with the production client contract.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No new issues require action. The previously reported provider test failure is fully fixed: `resetStore()` is mocked to return a resolved promise, matching the provider's promise rejection handling.

<sub>Reviews (3): Last reviewed commit: ["Fix tests and add changeset"](https://github.com/quiltt/quiltt-sdks/commit/c1272d343d903b989389142290d77cd375939faa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60684495)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [React SDK](https://app.greptile.com/quiltt/-/custom-context/knowledge-base/quiltt/quiltt-sdks/-/docs/react-sdk.md)
- Knowledge Base — [React providers and authentication state](https://app.greptile.com/quiltt/-/custom-context/knowledge-base/quiltt/quiltt-sdks/-/docs/react-providers-and-auth.md)
- Knowledge Base — [Vue SDK](https://app.greptile.com/quiltt/-/custom-context/knowledge-base/quiltt/quiltt-sdks/-/docs/vue-sdk.md)
- Knowledge Base — [Vue plugin and composables](https://app.greptile.com/quiltt/-/custom-context/knowledge-base/quiltt/quiltt-sdks/-/docs/vue-plugin-and-composables.md)
</details>


<!-- /greptile_comment -->