### PR TITLE
Fix mobile OAuth handoff preflight false-negatives

### DIFF
--- a/.changeset/gentle-books-kick.md
+++ b/.changeset/gentle-books-kick.md
@@ -1,0 +1,10 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/android": patch
+"@quiltt/flutter": patch
+"@quiltt/ios": patch
+---
+
+Fix OAuth handoff aborting on some Android 11+ devices when the URL-open preflight misreports. The mobile SDKs no longer treat `canOpenURL`/`canLaunchUrl`/`resolveActivity` as authoritative — they attempt to open the OAuth URL directly and fire `onExitError` only when the open itself fails, so bank redirects succeed on devices where package-visibility filtering would otherwise abort the flow.
+
+Fix `@quiltt/react-native` retrying the fallback URL with the raw double-encoded value, which could never open. The fallback now runs only when normalization changed the URL and the original is a well-formed HTTPS URL.

--- a/packages/android/connector/src/main/java/app/quiltt/connector/QuilttConnectorWebView.kt
+++ b/packages/android/connector/src/main/java/app/quiltt/connector/QuilttConnectorWebView.kt
@@ -213,16 +213,14 @@ class QuilttConnectorWebViewClient(private val params: QuilttConnectorWebViewCli
             return
         }
         
-        // Open the URL in the system browser
+        // Open the URL in the system browser. We intentionally skip
+        // `Intent.resolveActivity()` as a preflight — on Android 11+ it is
+        // subject to package-visibility filtering and can return null even when
+        // a browser is installed. `startActivity` throws
+        // `ActivityNotFoundException` if nothing can handle the intent.
         try {
             val intent = Intent(Intent.ACTION_VIEW, oauthUrl)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            // Preflight: verify an app is available to handle this intent
-            if (intent.resolveActivity(params.context.packageManager) == null) {
-                Log.e(TAG, "No app available to open URL: $oauthUrl")
-                fireOAuthFailure()
-                return
-            }
             params.context.startActivity(intent)
         } catch (error: Exception) {
             Log.e(TAG, "Failed to open URL in browser: $oauthUrl", error)

--- a/packages/android/connector/src/test/java/app/quiltt/connector/QuilttConnectorWebViewTest.kt
+++ b/packages/android/connector/src/test/java/app/quiltt/connector/QuilttConnectorWebViewTest.kt
@@ -134,6 +134,11 @@ class QuilttConnectorWebViewTest {
     @Test
     fun handleOAuthUrl_withHTTPS_noBrowserFiresFailure() {
         val context = RuntimeEnvironment.getApplication()
+        // Robolectric is permissive about unresolved intents by default; opt in to
+        // strict checking so startActivity throws like it does on a real device
+        // when no browser can handle the intent.
+        shadowOf(context).checkActivities(true)
+
         val config = QuilttConnectorConnectConfiguration(
             connectorId = "test-connector",
             appLauncherUrl = "https://example.com/callback",

--- a/packages/flutter/lib/src/platform/oauth_utils.dart
+++ b/packages/flutter/lib/src/platform/oauth_utils.dart
@@ -6,9 +6,9 @@ import '../../url_utils.dart';
 
 /// Handles opening an OAuth URL in an external browser.
 ///
-/// Wraps the preflight/launch sequence in a try/catch so that platform-channel
-/// failures (e.g. from [canLaunchUrlString] or [launchUrlString]) are handled
-/// gracefully and fire [fireOAuthFailure] instead of propagating.
+/// Wraps the launch sequence in a try/catch so that platform-channel failures
+/// (e.g. from [launchUrlString]) are handled gracefully and fire
+/// [fireOAuthFailure] instead of propagating.
 Future<void> handleOAuthUrl(
   String oauthUrl,
   String connectorId, {
@@ -20,18 +20,10 @@ Future<void> handleOAuthUrl(
   final normalizedUrl = URLUtils.normalizeUrlEncoding(oauthUrl);
 
   try {
-    // Preflight: verify the device can handle this URL scheme
-    if (!await canLaunchUrlString(normalizedUrl)) {
-      debugPrint('Quiltt: Cannot open OAuth URL: $normalizedUrl');
-      fireOAuthFailure(
-        connectorId,
-        onEvent: onEvent,
-        onExit: onExit,
-        onExitError: onExitError,
-      );
-      return;
-    }
-
+    // Attempt to open the URL directly. We intentionally skip
+    // `canLaunchUrlString()` as a preflight — it is unreliable on Android 11+
+    // under package-visibility filtering, whereas `launchUrlString` itself
+    // reports success/failure authoritatively.
     final launched = await launchUrlString(
       normalizedUrl,
       mode: LaunchMode.externalApplication,

--- a/packages/flutter/lib/src/platform/oauth_utils.dart
+++ b/packages/flutter/lib/src/platform/oauth_utils.dart
@@ -16,10 +16,11 @@ Future<void> handleOAuthUrl(
   void Function(ConnectorSDKOnEventExitCallback event)? onExit,
   void Function(ConnectorSDKOnExitErrorCallback event)? onExitError,
 }) async {
-  // Normalize the URL encoding to prevent issues with double-encoding
-  final normalizedUrl = URLUtils.normalizeUrlEncoding(oauthUrl);
-
   try {
+    // Normalization can throw on malformed escape sequences (e.g. "%ZZ"), so
+    // it must run inside this try to still report failure via fireOAuthFailure.
+    final normalizedUrl = URLUtils.normalizeUrlEncoding(oauthUrl);
+
     // Attempt to open the URL directly. We intentionally skip
     // `canLaunchUrlString()` as a preflight — it is unreliable on Android 11+
     // under package-visibility filtering, whereas `launchUrlString` itself
@@ -39,7 +40,7 @@ Future<void> handleOAuthUrl(
       );
     }
   } catch (e) {
-    debugPrint('Quiltt: Error opening OAuth URL: $normalizedUrl – $e');
+    debugPrint('Quiltt: Error opening OAuth URL: $oauthUrl – $e');
     fireOAuthFailure(
       connectorId,
       onEvent: onEvent,

--- a/packages/flutter/test/oauth_utils_test.dart
+++ b/packages/flutter/test/oauth_utils_test.dart
@@ -3,6 +3,30 @@ import 'package:quiltt_connector/event.dart';
 import 'package:quiltt_connector/src/platform/oauth_utils.dart';
 
 void main() {
+  group('handleOAuthUrl', () {
+    test(
+      'reports failure instead of throwing when the URL has a malformed escape sequence',
+      () async {
+        const malformedUrl =
+            'https://oauth.test.com/callback?code=abc%2520%ZZxyz';
+
+        ConnectorSDKOnExitErrorCallback? captured;
+
+        await expectLater(
+          handleOAuthUrl(
+            malformedUrl,
+            'test-connector',
+            onExitError: (event) => captured = event,
+          ),
+          completes,
+        );
+
+        expect(captured, isNotNull);
+        expect(captured!.eventMetadata.connectorId, equals('test-connector'));
+      },
+    );
+  });
+
   group('fireOAuthFailure', () {
     test('invokes all callbacks', () {
       ConnectorSDKOnEventCallback? capturedEvent;

--- a/packages/ios/Sources/QuilttConnector/QuilttConnectorWebview.swift
+++ b/packages/ios/Sources/QuilttConnector/QuilttConnectorWebview.swift
@@ -250,13 +250,8 @@ class QuilttConnectorWebview: WKWebView, WKNavigationDelegate {
         }
 
         #if canImport(UIKit) && os(iOS)
-            // Preflight: verify the device can handle this URL scheme
-            guard UIApplication.shared.canOpenURL(oauthUrl) else {
-                print("handleOAuthUrl - Cannot open URL: \(oauthUrl)")
-                fireOAuthFailure()
-                return
-            }
-
+            // Attempt to open the URL directly without a preflight check, since
+            // the `open` completion handler below reports success/failure authoritatively.
             if #available(iOS 10.0, *) {
                 UIApplication.shared.open(oauthUrl, options: [:]) { success in
                     if !success {

--- a/packages/react-native/src/components/QuilttConnector.tsx
+++ b/packages/react-native/src/components/QuilttConnector.tsx
@@ -107,40 +107,38 @@ export const handleOAuthUrl = async (
   oauthUrl: URL | string | null | undefined,
   onFailure?: (error: Error) => void
 ) => {
+  // Throw error if oauthUrl is null or undefined
+  if (oauthUrl == null) {
+    onFailure?.(new Error('OAuth URL missing'))
+    return
+  }
+
+  // Convert to string if it's a URL object
+  const urlString = oauthUrl.toString()
+
+  // Throw error if the resulting string is empty
+  if (!urlString || urlString.trim() === '') {
+    onFailure?.(new Error('Empty OAuth URL'))
+    return
+  }
+
+  // Normalize the URL encoding
+  const normalizedUrl = normalizeUrlEncoding(urlString)
+
   try {
-    // Throw error if oauthUrl is null or undefined
-    if (oauthUrl == null) {
-      throw new Error('OAuth URL missing')
-    }
-
-    // Convert to string if it's a URL object
-    const urlString = oauthUrl.toString()
-
-    // Throw error if the resulting string is empty
-    if (!urlString || urlString.trim() === '') {
-      throw new Error('Empty OAuth URL')
-    }
-
-    // Normalize the URL encoding
-    const normalizedUrl = normalizeUrlEncoding(urlString)
-
-    // Verify the device can handle this URL scheme before attempting to open
-    const canOpen = await Linking.canOpenURL(normalizedUrl)
-    if (!canOpen) {
-      throw new Error(`Device cannot open OAuth URL: ${normalizedUrl}`)
-    }
-
-    // Open the normalized URL
+    // Open the normalized URL directly without a preflight check, since
+    // `openURL()` reports success/failure authoritatively.
     await Linking.openURL(normalizedUrl)
   } catch (error) {
     console.error('OAuth URL handling error:', error)
 
-    // Only try the fallback if oauthUrl is not null
-    if (oauthUrl != null) {
+    // Only retry with the original URL if normalization changed it AND it is
+    // still a well-formed HTTPS URL. Opening a double-encoded value (e.g.
+    // "https%3A%2F%2F…") has no resolvable scheme and is guaranteed to fail.
+    if (urlString !== normalizedUrl && /^https:\/\//i.test(urlString)) {
       try {
-        const fallbackUrl = typeof oauthUrl === 'string' ? oauthUrl : oauthUrl.toString()
         console.log('Attempting fallback OAuth opening')
-        await Linking.openURL(fallbackUrl)
+        await Linking.openURL(urlString)
         return // fallback succeeded
       } catch (fallbackError) {
         console.error('Fallback OAuth opening failed:', fallbackError)

--- a/packages/react-native/src/components/QuilttConnector.tsx
+++ b/packages/react-native/src/components/QuilttConnector.tsx
@@ -122,10 +122,15 @@ export const handleOAuthUrl = async (
     return
   }
 
-  // Normalize the URL encoding
-  const normalizedUrl = normalizeUrlEncoding(urlString)
+  // Track whether normalization succeeded (and changed the URL) so the
+  // catch block can decide whether a fallback attempt is worthwhile.
+  let normalizedUrl = urlString
 
   try {
+    // Normalization can throw on malformed escape sequences (e.g. "%ZZ"), so
+    // it must run inside this try to still report failure via onFailure.
+    normalizedUrl = normalizeUrlEncoding(urlString)
+
     // Open the normalized URL directly without a preflight check, since
     // `openURL()` reports success/failure authoritatively.
     await Linking.openURL(normalizedUrl)

--- a/packages/react-native/tests/components/QuilttConnector.test.tsx
+++ b/packages/react-native/tests/components/QuilttConnector.test.tsx
@@ -75,7 +75,6 @@ describe('QuilttConnector', () => {
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(global, 'fetch')
-    vi.spyOn(Linking, 'canOpenURL').mockImplementation(() => Promise.resolve(true))
     vi.spyOn(Linking, 'openURL').mockImplementation(() => Promise.resolve(true))
     capturedWebViewProps = null
     capturedWebViewRef = null
@@ -91,7 +90,6 @@ describe('QuilttConnector', () => {
   describe('handleOAuthUrl', () => {
     beforeEach(() => {
       vi.clearAllMocks()
-      vi.mocked(Linking.canOpenURL).mockResolvedValue(true)
       vi.mocked(Linking.openURL).mockResolvedValue(true)
     })
 
@@ -107,9 +105,6 @@ describe('QuilttConnector', () => {
     })
 
     it('should handle empty string URLs', async () => {
-      // Mock openURL to reject so the fallback also fails
-      vi.mocked(Linking.openURL).mockRejectedValue(new Error('Cannot open empty URL'))
-
       const onFailure = vi.fn()
       await handleOAuthUrl('', onFailure)
       expect(onFailure).toHaveBeenCalledWith(expect.any(Error))
@@ -119,50 +114,45 @@ describe('QuilttConnector', () => {
       expect(onFailure).toHaveBeenCalledWith(expect.any(Error))
     })
 
-    it('should call canOpenURL before openURL', async () => {
+    it('should open the URL directly without a preflight check', async () => {
       const url = 'https://oauth.test.com/callback'
       await handleOAuthUrl(url)
 
-      expect(Linking.canOpenURL).toHaveBeenCalledWith(url)
       expect(Linking.openURL).toHaveBeenCalledWith(url)
     })
 
-    it('should fire onFailure when canOpenURL returns false', async () => {
-      // Both canOpenURL and openURL must fail so the fallback also fails
-      vi.mocked(Linking.canOpenURL).mockResolvedValue(false)
+    it('should fire onFailure when openURL rejects', async () => {
       vi.mocked(Linking.openURL).mockRejectedValue(new Error('Cannot open'))
 
       const onFailure = vi.fn()
       await handleOAuthUrl('https://oauth.test.com/callback', onFailure)
 
-      expect(Linking.canOpenURL).toHaveBeenCalled()
       expect(onFailure).toHaveBeenCalledWith(expect.any(Error))
     })
 
-    it('should attempt fallback when primary open fails', async () => {
-      // Primary canOpenURL succeeds, openURL rejects, then fallback also rejects
-      vi.mocked(Linking.canOpenURL).mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    it('should not fall back to the raw double-encoded URL', async () => {
+      const doubleEncodedUrl = 'https%3A%2F%2Foauth.test.com%2Fcallback%3Fcode%3Dabc%2520xyz'
       vi.mocked(Linking.openURL).mockRejectedValue(new Error('Cannot open'))
 
       const onFailure = vi.fn()
-      await handleOAuthUrl('https://oauth.test.com/callback', onFailure)
+      await handleOAuthUrl(doubleEncodedUrl, onFailure)
 
-      // Primary attempt: canOpenURL true, openURL rejects
-      // Fallback: canOpenURL false (second mock), onFailure fires
-      expect(onFailure).toHaveBeenCalled()
+      expect(Linking.openURL).toHaveBeenCalledTimes(1)
+      expect(Linking.openURL).toHaveBeenCalledWith('https://oauth.test.com/callback?code=abc%20xyz')
+      expect(onFailure).toHaveBeenCalledWith(expect.any(Error))
     })
 
     it('should normalize double-encoded URLs', async () => {
       const doubleEncodedUrl = 'https://oauth.test.com/callback?code=test%2520code'
       await handleOAuthUrl(doubleEncodedUrl)
-      expect(Linking.canOpenURL).toHaveBeenCalled()
-      expect(Linking.openURL).toHaveBeenCalled()
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://oauth.test.com/callback?code=test%20code'
+      )
     })
 
     it('should handle URL objects', async () => {
       const urlObject = new URL('https://oauth.test.com/callback')
       await handleOAuthUrl(urlObject)
-      expect(Linking.canOpenURL).toHaveBeenCalledWith('https://oauth.test.com/callback')
       expect(Linking.openURL).toHaveBeenCalledWith('https://oauth.test.com/callback')
     })
   })
@@ -377,7 +367,6 @@ describe('QuilttConnector', () => {
     it('should handle OAuth redirection', async () => {
       const url = new URL('https://oauth.test.com/callback')
       await handleOAuthUrl(url)
-      expect(Linking.canOpenURL).toHaveBeenCalledWith(url.toString())
       expect(Linking.openURL).toHaveBeenCalledWith(url.toString())
     })
   })

--- a/packages/react-native/tests/components/QuilttConnector.test.tsx
+++ b/packages/react-native/tests/components/QuilttConnector.test.tsx
@@ -150,6 +150,16 @@ describe('QuilttConnector', () => {
       )
     })
 
+    it('should report failure instead of throwing when the URL has a malformed escape sequence', async () => {
+      const malformedUrl = 'https://oauth.test.com/callback?code=abc%2520%ZZxyz'
+
+      const onFailure = vi.fn()
+      await expect(handleOAuthUrl(malformedUrl, onFailure)).resolves.toBeUndefined()
+
+      expect(Linking.openURL).not.toHaveBeenCalled()
+      expect(onFailure).toHaveBeenCalledWith(expect.any(Error))
+    })
+
     it('should handle URL objects', async () => {
       const urlObject = new URL('https://oauth.test.com/callback')
       await handleOAuthUrl(urlObject)

--- a/packages/react-native/vitest.setup.tsx
+++ b/packages/react-native/vitest.setup.tsx
@@ -76,7 +76,6 @@ const mockLinking = {
   openURL: vi.fn(),
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
-  canOpenURL: vi.fn(),
   getInitialURL: vi.fn(),
 }
 
@@ -88,7 +87,6 @@ vi.mock('react-native', () => ({
     openURL: vi.fn(),
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
-    canOpenURL: vi.fn(),
     getInitialURL: vi.fn(),
   },
   NativeModules: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,8 @@ overrides:
   brace-expansion@>4.0.0 <5.0.9: ^5.0.9
   browserslist@<=4.28.6: 4.28.7
   detox>yargs: 17.7.2
+  react-native>yargs: 17.7.2
+  '@react-native/codegen>yargs': 17.7.2
   fast-uri@<=3.1.5: 3.1.6
   h3@<=1.15.8: ^1.15.9
   iltorb: npm:noop2@^2.0.0
@@ -12499,7 +12501,7 @@ snapshots:
       hermes-parser: 0.29.1
       invariant: 2.2.4
       nullthrows: 1.1.1
-      yargs: 18.1.0
+      yargs: 17.7.2
 
   '@react-native/community-cli-plugin@0.81.5(supports-color@10.2.2)':
     dependencies:
@@ -18010,7 +18012,7 @@ snapshots:
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 8.21.1
-      yargs: 18.1.0
+      yargs: 17.7.2
     optionalDependencies:
       '@types/react': 19.2.18
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   brace-expansion@<=2.1.3: ^2.1.3
   brace-expansion@>4.0.0 <5.0.9: ^5.0.9
   browserslist@<=4.28.6: 4.28.7
-  detox>yargs: 18.1.0
+  detox>yargs: 17.7.2
   fast-uri@<=3.1.5: 3.1.6
   h3@<=1.15.8: ^1.15.9
   iltorb: npm:noop2@^2.0.0
@@ -4973,6 +4973,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
@@ -8051,6 +8055,10 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -9554,6 +9562,10 @@ packages:
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
@@ -14315,6 +14327,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -14674,7 +14692,7 @@ snapshots:
       trace-event-lib: 1.4.1
       which: 1.3.1
       ws: 8.21.1
-      yargs: 18.1.0
+      yargs: 17.7.2
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
     optionalDependencies:
@@ -18109,6 +18127,8 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   requireg@0.2.2:
@@ -19588,6 +19608,16 @@ snapshots:
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yargs@18.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,8 @@ overrides:
   'brace-expansion@<=2.1.3': ^2.1.3
   'brace-expansion@>4.0.0 <5.0.9': ^5.0.9
   'browserslist@<=4.28.6': 4.28.7
-  'detox>yargs': 18.1.0
+  # detox's CLI (yargs.scriptName) is incompatible with yargs 18's ESM-only API
+  'detox>yargs': 17.7.2
   'fast-uri@<=3.1.5': 3.1.6
   'h3@<=1.15.8': ^1.15.9
   'iltorb': npm:noop2@^2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ allowBuilds:
   esbuild: true
   sharp: true
 overrides:
+  '@react-native/codegen>yargs': 17.7.2
   '@turbo/darwin-64@<=2.9.18': 2.9.18
   '@turbo/linux-64@<=2.9.18': 2.9.18
   '@turbo/windows-64@<=2.9.18': 2.9.18
@@ -22,7 +23,6 @@ overrides:
   'brace-expansion@<=2.1.3': ^2.1.3
   'brace-expansion@>4.0.0 <5.0.9': ^5.0.9
   'browserslist@<=4.28.6': 4.28.7
-  # detox's CLI (yargs.scriptName) is incompatible with yargs 18's ESM-only API
   'detox>yargs': 17.7.2
   'fast-uri@<=3.1.5': 3.1.6
   'h3@<=1.15.8': ^1.15.9
@@ -32,6 +32,7 @@ overrides:
   'nanoid@<=5.1.16': 5.1.16
   'node-forge@<=1.4.0': ^1.4.0
   'query-string@7.1.3': 9.5.0
+  'react-native>yargs': 17.7.2
   'read-yaml-file>js-yaml': '>=3.15.2 <4'
   'serialize-javascript@<=7.0.5': ^7.0.5
   'sharp@<=0.35.0': 0.35.0


### PR DESCRIPTION
This PR fixes OAuth handoff failures on some Android 11+ devices where package-visibility filtering caused URL-open preflight checks (`canOpenURL`/`canLaunchUrl`/`resolveActivity`) to misreport, incorrectly aborting the connection flow even though a browser was available. The mobile SDKs (React Native, iOS, Android, Flutter) now attempt to open the OAuth URL directly and only fire `onExitError` if the open itself fails, relying on the platform's authoritative open-completion result instead of an unreliable preflight. It also fixes a bug in `@quiltt/react-native` where the fallback URL-opening path could retry with the raw, still double-encoded URL (which can never open), and removes the now-dead `canOpenURL` preflight code and tests from the React Native package.

Fixes #517 



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates dependency override metadata for the React Native CLI dependency tree. No new actionable issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No outstanding findings remain. The prior P1 thread was manually resolved without explanation by zubairaziz.

<sub>Reviews (3): Last reviewed commit: ["Add overrides for yargs"](https://github.com/quiltt/quiltt-sdks/commit/04e1c241bf8ee9464afb14161a7d54e806c83034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61486937)</sub>

**Context used:**

- Linear — [React Native: Android OAuth handoff fails when host app lacks <queries> — canOpenURL preflight (added in 6.0.1) aborts, and the fallback retries the un-normalized URL](https://linear.app/quiltt/issue/Q-1923/react-native-android-oauth-handoff-fails-when-host-app-lacks-queries)

<!-- /greptile_comment -->